### PR TITLE
chore: disable no-import-prefix

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -5,5 +5,17 @@
     "check": "deno check ./**/*.ts",
     "lint": "deno lint ./**/*.ts"
   },
-  "lock": false
+  "lock": false,
+  "fmt": {
+    "exclude": [
+      "CHANGELOG.md"
+    ]
+  },
+  "lint": {
+    "rules": {
+      "exclude": [
+        "no-import-prefix"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
we dont use deno.lock and deno.jsonc (what is differ from package.json?)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tool configuration for code formatting and linting with refined exclusion rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->